### PR TITLE
Add company_name field to Bot creation and refresh token endpoint

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -24,6 +24,7 @@ class AuthController {
                 user.Bot = await db.Bot.create({
                     userId: user.id,
                     bot_name: `${user.name}'s Bot`,
+                    company_name: `${user.name}'s Company`,
                 });
             }
 

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -232,6 +232,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/auth/refresh:
+    post:
+      tags:
+        - Authentication
+      summary: User refresh token
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                refresh_token:
+                  type: string
+      responses:
+        '200':
+          description: Refresh token successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string
+                  token_type:
+                    type: string
+                  expires_in:
+                    type: integer
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/bot-settings:
     get:
@@ -265,7 +299,7 @@ paths:
         - Bot Settings
       summary: Update bot settings
       security:
-        - BearerAuth: []
+        - BearerAuth: [ ]
       requestBody:
         required: true
         content:


### PR DESCRIPTION
<details>
  <summary>Details</summary>
  
  - Updated Bot creation logic to include `company_name` field
  - Added new `/api/auth/refresh` endpoint for token refresh
  - Updated Swagger documentation for request and response schemas
</details>